### PR TITLE
Add logging init to ffi and make errors more convinient

### DIFF
--- a/.cbindgen.toml
+++ b/.cbindgen.toml
@@ -1,0 +1,8 @@
+language = "C"
+pragma_once = true
+line_length = 80
+documentation_style = "doxy"
+
+[enum]
+rename_variants = "SnakeCase"
+prefix_with_name = true

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build-release-static: ## Build the main binary in release mode statically linked
 		-v "$(shell pwd)":/volume \
 		-v ~/.cargo/git:/root/.cargo/git \
 		-v ~/.cargo/registry:/root/.cargo/registry \
-		clux/muslrust \
+		clux/muslrust:stable \
 		bash -c "\
 			rustup component add rustfmt && \
 			make build-release && \

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
-use anyhow::{Context, Result};
-use cbindgen::{Builder, Language};
+use anyhow::{format_err, Context, Result};
+use cbindgen::{Builder, Config};
 use std::{env, path::PathBuf};
 
 const PROTO_FILE: &str = "src/kubernetes/cri/proto/criapi.proto";
@@ -19,8 +19,7 @@ fn main() -> Result<()> {
 
     Builder::new()
         .with_crate(env::var("CARGO_MANIFEST_DIR")?)
-        .with_language(Language::C)
-        .with_pragma_once(true)
+        .with_config(Config::from_file(".cbindgen.toml").map_err(|e| format_err!(e))?)
         .generate()
         .context("generate bindings")?
         .write_to_file("src/ffi/ffi.h");

--- a/src/ffi/ffi.h
+++ b/src/ffi/ffi.h
@@ -6,8 +6,39 @@
 #include <stdlib.h>
 
 /**
- * Calculate the number of bytes in the last error's error message including a trailing `null`
- * character. If there are no recent error, then this returns `0`.
+ * An enum representing the available verbosity level filters of the logger.
+ */
+typedef enum {
+  /**
+   * A level lower than all log levels.
+   */
+  log_level_off,
+  /**
+   * Corresponds to the `Error` log level.
+   */
+  log_level_error,
+  /**
+   * Corresponds to the `Warn` log level.
+   */
+  log_level_warn,
+  /**
+   * Corresponds to the `Info` log level.
+   */
+  log_level_info,
+  /**
+   * Corresponds to the `Debug` log level.
+   */
+  log_level_debug,
+  /**
+   * Corresponds to the `Trace` log level.
+   */
+  log_level_trace,
+} LogLevel;
+
+/**
+ * Calculate the number of bytes in the last error's error message including a
+ * trailing `null` character. If there are no recent error, then this returns
+ * `0`.
  */
 int last_error_length(void);
 
@@ -25,3 +56,9 @@ int last_error_length(void);
  * when passed a `null` pointer or a buffer of insufficient size.
  */
 int last_error_message(char *buffer, int length);
+
+/**
+ * Init the log level by the provided level string.
+ * Populates the last error on any failure.
+ */
+void log_init(LogLevel level);

--- a/src/ffi/log.rs
+++ b/src/ffi/log.rs
@@ -1,0 +1,62 @@
+//! Logging faccade for the FFI
+
+use crate::ffi::error::update_last_err_if_required;
+use anyhow::{Context, Result};
+use clap::crate_name;
+use std::env;
+use strum::AsRefStr;
+
+#[repr(C)]
+#[allow(dead_code)]
+#[derive(Debug, AsRefStr)]
+#[strum(serialize_all = "snake_case")]
+/// An enum representing the available verbosity level filters of the logger.
+pub enum LogLevel {
+    /// A level lower than all log levels.
+    Off,
+
+    /// Corresponds to the `Error` log level.
+    Error,
+
+    /// Corresponds to the `Warn` log level.
+    Warn,
+
+    /// Corresponds to the `Info` log level.
+    Info,
+
+    /// Corresponds to the `Debug` log level.
+    Debug,
+
+    /// Corresponds to the `Trace` log level.
+    Trace,
+}
+
+#[no_mangle]
+/// Init the log level by the provided level string.
+/// Populates the last error on any failure.
+pub extern "C" fn log_init(level: LogLevel) {
+    update_last_err_if_required(log_init_res(level))
+}
+
+fn log_init_res(level: LogLevel) -> Result<()> {
+    env::set_var("RUST_LOG", format!("{}={}", crate_name!(), level.as_ref()));
+    env_logger::try_init().context("init log level")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ffi::error::last_error_length;
+
+    #[test]
+    fn log_init_success() {
+        log_init(LogLevel::Error);
+        assert_eq!(last_error_length(), 0);
+    }
+
+    #[test]
+    fn log_level() {
+        assert_eq!(LogLevel::Error.as_ref(), "error");
+        assert_eq!(LogLevel::Debug.as_ref(), "debug");
+    }
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,4 +1,5 @@
 //! FFI related implementations
 
 mod error;
+mod log;
 mod network;


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This allows us to init the logging via the FFI as well as adding a
convenient function to automatically unsetting the last error of a
result succeeded.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
